### PR TITLE
Use symbols instead of strings to find matching methods

### DIFF
--- a/main/src/main/scala/demo/Demo2.scala
+++ b/main/src/main/scala/demo/Demo2.scala
@@ -1,0 +1,17 @@
+//package demo
+//package unicredit
+package demo.unicredit
+
+
+class Foo2 {
+  def hello() = "hi"
+}
+
+class Foo3 {
+  def hello() = "hi there"
+}
+
+object Demo2 extends App {
+  val foo = new Foo3
+  println(foo.hello()+" planet")
+}

--- a/method_eraser.config
+++ b/method_eraser.config
@@ -1,2 +1,3 @@
 pippo.Pluto.ciao
 demo.unicredit.Foo.hello
+demo.unicredit.Foo2.hello


### PR DESCRIPTION
This requires running the plugin components after the `namer`
phase.

With symbols it is no longer necessary to change the method name
that we are looking for while traversing the tree. Thus, scoping
issues are avoided by design.
